### PR TITLE
docs(readme): update cp config ini file command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ This Node.js script connects to the Trade Republic WebSocket API, retrieves your
 1. Copy the example config file:
 
 ```bash
-cp config.ini.exemple .config.ini
+cp config.ini.exemple config.ini
 ```
 
 2. Edit .config.ini with your Trade Republic credentials:


### PR DESCRIPTION
When copying/pasting the command provided in the readme, I get the following error : `Fichier config.ini introuvable.`
There is only a small typo: the output filename being `.config.ini` instead of `config.ini` to make the script work

Thank a lot for your script btw!

